### PR TITLE
Fix register endpoint URL

### DIFF
--- a/public/js/register.js
+++ b/public/js/register.js
@@ -9,7 +9,7 @@ document.getElementById('register-form').addEventListener('submit', async (event
     const errorMessage = document.getElementById('register-error-message');
 
     try {
-        const response = await fetch('http://localhost:5000/api/register', {
+        const response = await fetch('/api/register', {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json'


### PR DESCRIPTION
## Summary
- fix sign-up API endpoint to match server port

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68733faafc188322acd2c5c103f5a68c